### PR TITLE
Fix typo in board rules helper

### DIFF
--- a/src/utils/gameRules.ts
+++ b/src/utils/gameRules.ts
@@ -25,7 +25,7 @@ export const validateMove = (
   }
   
   // Check if tiles are placed in a single row or column
-  if (!aretilesInLine(newTiles)) {
+  if (!areTilesInLine(newTiles)) {
     errors.push('Tiles must be placed in a single row or column')
   }
   
@@ -62,7 +62,7 @@ export const validateMove = (
   }
 }
 
-const aretilesInLine = (tiles: PlacedTile[]): boolean => {
+const areTilesInLine = (tiles: PlacedTile[]): boolean => {
   if (tiles.length <= 1) return true
   
   // Check if all tiles are in the same row


### PR DESCRIPTION
## Summary
- rename `aretilesInLine` to `areTilesInLine`

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_688627b86adc832094f3ecdcf26e6a85