### PR TITLE
Fix pass comment

### DIFF
--- a/src/components/GameFlow.tsx
+++ b/src/components/GameFlow.tsx
@@ -21,7 +21,7 @@ export const GameFlow = () => {
   const handlePass = useCallback(() => {
     setPassCount(prev => prev + 1)
     
-    // If both players pass twice, end game
+    // Game ends after each player has passed twice (four total passes)
     if (passCount >= 3) {
       // Game ends - calculate final scores
       return


### PR DESCRIPTION
## Summary
- clarify pass-ending comment in GameFlow

## Testing
- `npm run lint` *(fails: no-empty-object-type, no-case-declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688627bcb5f88320bf6c548cef89b786