### PR TITLE
Fix bot difficulty persistence

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -8,7 +8,6 @@ import { TileActions } from "@/components/TileActions"
 import { DictionaryLoader } from "@/components/DictionaryLoader"
 import { ArrowLeft } from "lucide-react"
 import { Link } from "react-router-dom"
-import { BotProvider } from "@/contexts/BotContext"
 
 const GameContent = () => {
   const { 
@@ -183,11 +182,9 @@ const GameContent = () => {
 
 const Game = () => {
   return (
-    <BotProvider>
-      <GameProvider>
-        <GameContent />
-      </GameProvider>
-    </BotProvider>
+    <GameProvider>
+      <GameContent />
+    </GameProvider>
   )
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,10 +1,8 @@
 import { PlayButtons } from "@/components/PlayButtons"
-import { BotProvider } from "@/contexts/BotContext"
 
 const Index = () => {
   return (
-    <BotProvider>
-      <div className="container mx-auto p-6 max-w-4xl">
+    <div className="container mx-auto p-6 max-w-4xl">
         <div className="text-center space-y-6">
           <div>
             <h1 className="text-4xl font-bold mb-4">Welcome to Scrabble Online</h1>
@@ -40,7 +38,6 @@ const Index = () => {
           </div>
         </div>
       </div>
-    </BotProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- remove nested `BotProvider` instances in pages
- ensure selected bot difficulty persists across routes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68873ad64e8c832084cf587d00a590cd