### PR TITLE
Update move validation logic

### DIFF
--- a/src/utils/moveValidation.test.ts
+++ b/src/utils/moveValidation.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { validateMoveLogic } from './moveValidation'
+import type { PlacedTile } from '@/types/game'
+
+describe('validateMoveLogic', () => {
+  it('allows separated tiles bridged by existing tiles', () => {
+    const board = new Map<string, PlacedTile>()
+    const pTile: PlacedTile = { row: 7, col: 7, letter: 'P', points: 3 }
+    board.set('7,7', pTile)
+
+    const nTile: PlacedTile = { row: 7, col: 6, letter: 'N', points: 1 }
+    const eTile: PlacedTile = { row: 7, col: 8, letter: 'E', points: 1 }
+
+    const result = validateMoveLogic(board, [nTile, eTile])
+    expect(result.isValid).toBe(true)
+    expect(result.errors).not.toContain('All new tiles must be adjacent to each other')
+  })
+})

--- a/src/utils/moveValidation.ts
+++ b/src/utils/moveValidation.ts
@@ -25,9 +25,12 @@ export const validateMoveLogic = (
       errors.push('Cannot place tile on occupied square')
     }
   }
-  
+
+  const contiguous = areNewTilesContiguous(newTiles)
+  const gapsFilled = areGapsFilledByExistingTiles(board, newTiles)
+
   // Check if tiles are contiguous
-  if (newTiles.length > 1 && !areNewTilesContiguous(newTiles)) {
+  if (newTiles.length > 1 && !contiguous && !gapsFilled) {
     errors.push('All new tiles must be adjacent to each other')
   }
   
@@ -47,7 +50,7 @@ export const validateMoveLogic = (
   }
   
   // Check if gaps are filled by existing tiles
-  if (!areGapsFilledByExistingTiles(board, newTiles)) {
+  if (!gapsFilled) {
     errors.push('Gaps between new tiles must be filled by existing tiles')
   }
   


### PR DESCRIPTION
## Summary
- compute contiguity and filled gaps once in `validateMoveLogic`
- relax adjacency error when gaps are bridged with existing tiles
- add test covering non-contiguous placements bridged by existing letters

## Testing
- `npm test --silent --prefix .`

------
https://chatgpt.com/codex/tasks/task_e_6887740c8df483209d6963013c2b03bd