### PR TITLE
Handle blank Scrabble tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Blank tiles
+
+When you drag a blank tile onto the board a dialog will appear allowing you to choose which letter it represents. The chosen letter is displayed on the tile but the tile still scores `0` points and remains a blank tile. Picking the tile back up lets you choose again on the next placement.

--- a/src/components/BlankTileDialog.tsx
+++ b/src/components/BlankTileDialog.tsx
@@ -1,0 +1,37 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+
+interface BlankTileDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (letter: string) => void
+}
+
+const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
+
+export const BlankTileDialog = ({ open, onOpenChange, onSelect }: BlankTileDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Select Letter</DialogTitle>
+        </DialogHeader>
+        <div className="grid grid-cols-6 gap-2">
+          {letters.map((l) => (
+            <Button
+              key={l}
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                onSelect(l)
+                onOpenChange(false)
+              }}
+            >
+              {l}
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/ScrabbleBoard.tsx
+++ b/src/components/ScrabbleBoard.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils"
 import { ScrabbleTile } from "./ScrabbleTile"
 import { useState } from "react"
+import { BlankTileDialog } from "./BlankTileDialog"
 
 // Definizioni delle caselle speciali
 const SPECIAL_SQUARES = {
@@ -80,6 +81,7 @@ export const ScrabbleBoard = ({
   disabled = false
 }: ScrabbleBoardProps) => {
   const [dragOverSquare, setDragOverSquare] = useState<string | null>(null)
+  const [blankTileData, setBlankTileData] = useState<{ row: number; col: number; tile: PlacedTile } | null>(null)
   const handleDrop = (e: React.DragEvent, row: number, col: number) => {
     if (disabled) return
     e.preventDefault()
@@ -100,8 +102,12 @@ export const ScrabbleBoard = ({
           row,
           col
         }
-        
-        onTilePlaced?.(row, col, newTile)
+
+        if (newTile.isBlank) {
+          setBlankTileData({ row, col, tile: newTile })
+        } else {
+          onTilePlaced?.(row, col, newTile)
+        }
       }
     } catch (error) {
       console.error("Failed to parse drop data:", error)
@@ -185,6 +191,21 @@ export const ScrabbleBoard = ({
           Array.from({ length: 15 }, (_, col) => renderSquare(row, col))
         )}
       </div>
+      <BlankTileDialog
+        open={!!blankTileData}
+        onOpenChange={(open) => {
+          if (!open) setBlankTileData(null)
+        }}
+        onSelect={(letter) => {
+          if (blankTileData) {
+            onTilePlaced?.(blankTileData.row, blankTileData.col, {
+              ...blankTileData.tile,
+              letter,
+            })
+            setBlankTileData(null)
+          }
+        }}
+      />
     </div>
   )
 }

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -70,9 +70,10 @@ export const useGame = () => {
       
       // Remove tile from current player's rack
       const currentPlayer = prev.players[prev.currentPlayerIndex]
-      const tileIndex = currentPlayer.rack.findIndex(t => 
-        t.letter === tile.letter && t.points === tile.points && t.isBlank === tile.isBlank
-      )
+      const tileIndex = currentPlayer.rack.findIndex(t => {
+        if (tile.isBlank && t.isBlank) return true
+        return t.letter === tile.letter && t.points === tile.points && t.isBlank === tile.isBlank
+      })
       
       if (tileIndex === -1) return prev // Tile not found in rack
       
@@ -387,9 +388,10 @@ export const useGame = () => {
           const currentPlayer = prevState.players[prevState.currentPlayerIndex]
           const newRack = [...currentPlayer.rack]
           bestMove.tiles.forEach(usedTile => {
-            const tileIndex = newRack.findIndex(t => 
-              t.letter === usedTile.letter && t.points === usedTile.points
-            )
+            const tileIndex = newRack.findIndex(t => {
+              if (usedTile.isBlank && t.isBlank) return true
+              return t.letter === usedTile.letter && t.points === usedTile.points
+            })
             if (tileIndex !== -1) {
               newRack.splice(tileIndex, 1)
             }

--- a/src/utils/moveValidation.test.ts
+++ b/src/utils/moveValidation.test.ts
@@ -15,4 +15,14 @@ describe('validateMoveLogic', () => {
     expect(result.isValid).toBe(true)
     expect(result.errors).not.toContain('All new tiles must be adjacent to each other')
   })
+
+  it('validates moves with blank tiles assigned a letter', () => {
+    const board = new Map<string, PlacedTile>()
+
+    const blankTile: PlacedTile = { row: 7, col: 7, letter: 'A', points: 0, isBlank: true }
+
+    const result = validateMoveLogic(board, [blankTile])
+
+    expect(result.isValid).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- support choosing a letter for blank tiles via `BlankTileDialog`
- prompt when dropping a blank tile on the board
- remove blank tiles from racks correctly
- validate blank tile moves in tests
- document blank tile behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68877c70b60483208171e102a3fe1e09