### PR TITLE
Implement dark theme toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Dictionary from "./pages/Dictionary";
 import NotFound from "./pages/NotFound";
 import { BotProvider } from "./contexts/BotContext";
 import { DictionaryProvider } from "./contexts/DictionaryContext";
+import { ThemeToggle } from "./components/ThemeToggle";
 
 const queryClient = new QueryClient();
 
@@ -29,6 +30,7 @@ const App = () => (
                 <header className="h-14 border-b border-border flex items-center px-4">
                   <SidebarTrigger />
                   <h2 className="ml-4 text-lg font-semibold">Scrabble Online</h2>
+                  <ThemeToggle />
                 </header>
                 <main className="flex-1 overflow-auto">
                   <Routes>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+
+export const ThemeToggle = () => {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  const toggleTheme = () => {
+    setTheme(isDark ? "light" : "dark");
+  };
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} className="ml-auto">
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { createRoot } from 'react-dom/client'
+import { ThemeProvider } from 'next-themes'
 import { DictionaryProvider } from './contexts/DictionaryContext'
 import App from './App.tsx'
 import './index.css'
 
 createRoot(document.getElementById("root")!).render(
-  <DictionaryProvider>
-    <App />
-  </DictionaryProvider>
+  <ThemeProvider attribute="class" defaultTheme="light">
+    <DictionaryProvider>
+      <App />
+    </DictionaryProvider>
+  </ThemeProvider>
 );


### PR DESCRIPTION
## Summary
- add a `ThemeToggle` button component
- wrap the app in `ThemeProvider`
- show the toggle button in the header

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68877e4b5aa883209cc1ad626b64b6c6