### PR TITLE
UI adjustments for simplified game

### DIFF
--- a/src/components/DifficultyModal.tsx
+++ b/src/components/DifficultyModal.tsx
@@ -1,7 +1,6 @@
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
@@ -21,21 +20,18 @@ const difficultyOptions = [
   {
     id: 'easy' as const,
     name: 'Easy',
-    description: 'Good for beginners. Makes basic moves and simple words.',
     stars: 1,
     color: 'bg-green-500'
   },
   {
     id: 'medium' as const,
-    name: 'Medium', 
-    description: 'Balanced gameplay. Uses strategic positioning and varied vocabulary.',
+    name: 'Medium',
     stars: 3,
     color: 'bg-yellow-500'
   },
   {
     id: 'hard' as const,
     name: 'Hard',
-    description: 'Expert level. Maximizes points with complex strategies and advanced words.',
     stars: 5,
     color: 'bg-red-500'
   }
@@ -50,9 +46,6 @@ export const DifficultyModal = ({ open, onOpenChange, onSelectDifficulty }: Diff
             <Bot className="h-5 w-5" />
             Choose Bot Difficulty
           </DialogTitle>
-          <DialogDescription>
-            Select the difficulty level for your computer opponent.
-          </DialogDescription>
         </DialogHeader>
         
         <div className="space-y-4">
@@ -79,9 +72,6 @@ export const DifficultyModal = ({ open, onOpenChange, onSelectDifficulty }: Diff
                       </div>
                     </Badge>
                   </div>
-                  <p className="text-sm text-muted-foreground">
-                    {option.description}
-                  </p>
                 </div>
               </div>
             </Button>

--- a/src/components/PlayButtons.tsx
+++ b/src/components/PlayButtons.tsx
@@ -52,9 +52,6 @@ export const PlayButtons = () => {
             <CardHeader className="text-center">
               <Bot className="h-12 w-12 mx-auto text-primary mb-2 group-hover:scale-110 transition-transform" />
               <CardTitle>Gioca contro Computer</CardTitle>
-              <CardDescription>
-                Allena le tue abilità contro bot di crescente difficoltà
-              </CardDescription>
             </CardHeader>
             <CardContent>
               <Button className="w-full" onClick={handleBotPlay}>

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -7,12 +7,9 @@ interface GameContextType {
   pendingTiles: PlacedTile[]
   placeTile: (row: number, col: number, tile: Tile) => void
   pickupTile: (row: number, col: number) => void
-  confirmMove: () => void
-  cancelMove: () => void
-  endTurn: () => void
   resetGame: () => void
   reshuffleTiles: () => void
-  collectAllTiles: () => void
+  exchangeTiles: () => void
   passTurn: () => void
   makeBotMove: () => Promise<void>
   isBotTurn: boolean
@@ -36,9 +33,39 @@ interface GameProviderProps {
 
 export const GameProvider = ({ children }: GameProviderProps) => {
   const gameLogic = useGame()
-  
+
+  const {
+    gameState,
+    pendingTiles,
+    placeTile,
+    pickupTile,
+    resetGame,
+    reshuffleTiles,
+    exchangeTiles,
+    passTurn,
+    makeBotMove,
+    isBotTurn,
+    currentPlayer,
+    isCurrentPlayerTurn
+  } = gameLogic
+
   return (
-    <GameContext.Provider value={gameLogic}>
+    <GameContext.Provider
+      value={{
+        gameState,
+        pendingTiles,
+        placeTile,
+        pickupTile,
+        resetGame,
+        reshuffleTiles,
+        exchangeTiles,
+        passTurn,
+        makeBotMove,
+        isBotTurn,
+        currentPlayer,
+        isCurrentPlayerTurn
+      }}
+    >
       {children}
     </GameContext.Provider>
   )

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -247,25 +247,32 @@ export const useGame = () => {
     })
   }, [])
 
-  const collectAllTiles = useCallback(() => {
-    if (pendingTiles.length === 0) return
-    
+  const exchangeTiles = useCallback(() => {
     setGameState(prev => {
       const currentPlayer = prev.players[prev.currentPlayerIndex]
+      const rackSize = currentPlayer.rack.length
+
+      if (prev.tileBag.length < rackSize) return prev
+
+      const bagWithReturned = shuffleArray([...prev.tileBag, ...currentPlayer.rack])
+      const { drawn, remaining } = drawTiles(bagWithReturned, rackSize)
+
       const newPlayers = [...prev.players]
       newPlayers[prev.currentPlayerIndex] = {
         ...currentPlayer,
-        rack: [...currentPlayer.rack, ...pendingTiles]
+        rack: drawn
       }
-      
-      setPendingTiles([])
-      
+
       return {
         ...prev,
-        players: newPlayers
+        players: newPlayers,
+        tileBag: remaining,
+        currentPlayerIndex: (prev.currentPlayerIndex + 1) % prev.players.length,
+        passCount: 0
       }
     })
-  }, [pendingTiles])
+  }, [])
+
 
   const passTurn = useCallback(() => {
     setGameState(prev => {
@@ -471,12 +478,9 @@ export const useGame = () => {
     pendingTiles,
     placeTile,
     pickupTile,
-    confirmMove,
-    cancelMove,
-    endTurn,
     resetGame,
     reshuffleTiles,
-    collectAllTiles,
+    exchangeTiles,
     passTurn,
     makeBotMove,
     isBotTurn,

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -11,17 +11,14 @@ import { Link } from "react-router-dom"
 const GameContent = () => {
   const { 
     gameState, 
-    pendingTiles, 
-    placeTile, 
+    pendingTiles,
+    placeTile,
     pickupTile,
-    confirmMove, 
-    cancelMove, 
-    endTurn, 
-    resetGame, 
+    resetGame,
     currentPlayer,
     reshuffleTiles,
-    collectAllTiles,
     passTurn,
+    exchangeTiles,
     isBotTurn
   } = useGameContext()
 
@@ -38,117 +35,8 @@ const GameContent = () => {
       </div>
 
       <div className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="border rounded-lg p-4">
-            <h3 className="font-semibold mb-2">Players</h3>
-            <div className="space-y-2 text-sm">
-              {gameState.players.map((player, index) => (
-                <div
-                  key={player.id}
-                  className={`p-2 rounded ${
-                    index === gameState.currentPlayerIndex
-                      ? 'bg-primary/10 border border-primary'
-                      : 'bg-secondary'
-                  }`}
-                >
-                  <div className="flex justify-between">
-                    <span className="font-medium">{player.name}</span>
-                    <span className={index === gameState.currentPlayerIndex ? 'text-primary' : 'text-muted-foreground'}>
-                      {index === gameState.currentPlayerIndex ? 'Active turn' : 'Waiting'}
-                    </span>
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    Score: {player.score} | Tiles: {player.rack.length}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="border rounded-lg p-4">
-            <h3 className="font-semibold mb-2">Game Status</h3>
-            <div className="text-sm space-y-1">
-              <div className="flex justify-between">
-                <span>Status:</span>
-                <span className="font-medium capitalize">{gameState.gameStatus}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Tiles in bag:</span>
-                <span>{gameState.tileBag.length}</span>
-              </div>
-              <div className="flex justify-between">
-                <span>Tiles played:</span>
-                <span>{gameState.board.size}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <GameFlow />
-
-        {/* Main game area */}
         <div className="space-y-6">
-          <div className="text-center">
-            <p className="text-lg font-medium">
-              Turn: {currentPlayer.name} (Score: {currentPlayer.score})
-              {isBotTurn && currentPlayer.isBot && (
-                <span className="ml-2 text-sm text-muted-foreground animate-pulse">
-                  🤖 Bot is thinking...
-                </span>
-              )}
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Tiles remaining: {gameState.tileBag.length} | 
-              Game mode: {gameState.gameMode === 'bot' ? 'vs Bot' : 'Multiplayer'}
-            </p>
-          </div>
-
-          <div className="flex justify-center gap-2 flex-wrap">
-            {pendingTiles.length > 0 && (
-              <>
-                <Button 
-                  onClick={confirmMove} 
-                  variant="default"
-                  disabled={isBotTurn}
-                >
-                  Confirm Move ({pendingTiles.length} tiles)
-                </Button>
-                <Button 
-                  onClick={cancelMove} 
-                  variant="outline"
-                  disabled={isBotTurn}
-                >
-                  Cancel Move
-                </Button>
-                <Button 
-                  onClick={collectAllTiles} 
-                  variant="outline"
-                  disabled={isBotTurn}
-                >
-                  Collect All
-                </Button>
-              </>
-            )}
-            <Button 
-              onClick={passTurn} 
-              variant="outline" 
-              disabled={pendingTiles.length > 0 || isBotTurn || currentPlayer.isBot}
-            >
-              Pass Turn
-            </Button>
-            <Button 
-              onClick={endTurn} 
-              variant="outline" 
-              disabled={pendingTiles.length > 0 || isBotTurn || currentPlayer.isBot}
-            >
-              End Turn
-            </Button>
-            <Button onClick={resetGame} variant="outline">
-              New Game
-            </Button>
-          </div>
-
-          <div className="bg-card p-6 rounded-lg shadow-lg">
+          <div className="bg-card p-6 rounded-lg shadow-lg relative">
             <div className="flex justify-center">
               <ScrabbleBoard
                 placedTiles={gameState.board}
@@ -157,16 +45,41 @@ const GameContent = () => {
                 onTilePickup={(row, col) => pickupTile(row, col)}
                 disabled={isBotTurn || currentPlayer.isBot}
               />
+              <div className="absolute bottom-2 right-2 bg-secondary rounded p-2 text-sm shadow">
+                {gameState.players.map(p => (
+                  <div key={p.id} className="flex justify-between gap-4">
+                    <span>{p.name}</span>
+                    <span className="font-medium">{p.score}</span>
+                  </div>
+                ))}
+              </div>
             </div>
             {!currentPlayer.isBot && (
               <div className="mt-6 space-y-4">
                 <TileRack tiles={currentPlayer.rack} />
-                <TileActions 
-                  onReshuffle={reshuffleTiles}
-                  onCollectAll={collectAllTiles}
-                  hasPendingTiles={pendingTiles.length > 0}
-                  disabled={isBotTurn}
-                />
+                <div className="flex justify-center gap-2">
+                  <Button
+                    onClick={passTurn}
+                    variant="outline"
+                    disabled={isBotTurn}
+                  >
+                    Pass Turn
+                  </Button>
+                  <Button
+                    onClick={exchangeTiles}
+                    variant="outline"
+                    disabled={isBotTurn || gameState.tileBag.length < currentPlayer.rack.length}
+                  >
+                    Swap Tiles
+                  </Button>
+                  <Button
+                    onClick={reshuffleTiles}
+                    variant="outline"
+                    disabled={isBotTurn}
+                  >
+                    Reshuffle Tiles
+                  </Button>
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- simplify play button text
- remove difficulty descriptions from difficulty modal
- add exchange tiles logic
- update game context to expose new function
- show minimal board UI with score overlay and essential buttons

## Testing
- `npm test`
- `npm run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_688787dada388320acaac88e7c519cf1