### PR TITLE
Add word confirmation controls

### DIFF
--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -8,6 +8,8 @@ interface GameContextType {
   placeTile: (row: number, col: number, tile: Tile) => void
   pickupTile: (row: number, col: number) => void
   resetGame: () => void
+  confirmMove: () => void
+  cancelMove: () => void
   reshuffleTiles: () => void
   exchangeTiles: () => void
   passTurn: () => void
@@ -39,6 +41,8 @@ export const GameProvider = ({ children }: GameProviderProps) => {
     pendingTiles,
     placeTile,
     pickupTile,
+    confirmMove,
+    cancelMove,
     resetGame,
     reshuffleTiles,
     exchangeTiles,
@@ -56,6 +60,8 @@ export const GameProvider = ({ children }: GameProviderProps) => {
         pendingTiles,
         placeTile,
         pickupTile,
+        confirmMove,
+        cancelMove,
         resetGame,
         reshuffleTiles,
         exchangeTiles,

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -478,6 +478,8 @@ export const useGame = () => {
     pendingTiles,
     placeTile,
     pickupTile,
+    confirmMove,
+    cancelMove,
     resetGame,
     reshuffleTiles,
     exchangeTiles,

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -9,11 +9,13 @@ import { ArrowLeft } from "lucide-react"
 import { Link } from "react-router-dom"
 
 const GameContent = () => {
-  const { 
-    gameState, 
+  const {
+    gameState,
     pendingTiles,
     placeTile,
     pickupTile,
+    confirmMove,
+    cancelMove,
     resetGame,
     currentPlayer,
     reshuffleTiles,
@@ -57,7 +59,20 @@ const GameContent = () => {
             {!currentPlayer.isBot && (
               <div className="mt-6 space-y-4">
                 <TileRack tiles={currentPlayer.rack} />
-                <div className="flex justify-center gap-2">
+                <div className="flex flex-wrap justify-center gap-2">
+                  <Button
+                    onClick={confirmMove}
+                    disabled={isBotTurn || pendingTiles.length === 0}
+                  >
+                    Confirm Move
+                  </Button>
+                  <Button
+                    onClick={cancelMove}
+                    variant="outline"
+                    disabled={isBotTurn || pendingTiles.length === 0}
+                  >
+                    Cancel
+                  </Button>
                   <Button
                     onClick={passTurn}
                     variant="outline"


### PR DESCRIPTION
## Summary
- allow confirming or cancelling the current move in single player mode
- expose `confirmMove` and `cancelMove` via context

## Testing
- `npm run build:dev`
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e1f9bf3883208eae513614490afa