### PR TITLE
Add tap-based tile placement for mobile

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -6,6 +6,8 @@ import { TileRack } from "@/components/TileRack"
 import { TileActions } from "@/components/TileActions"
 import { DictionaryLoader } from "@/components/DictionaryLoader"
 import { ArrowLeft } from "lucide-react"
+import { useState } from "react"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { Link } from "react-router-dom"
 
 const GameContent = () => {
@@ -23,6 +25,19 @@ const GameContent = () => {
     exchangeTiles,
     isBotTurn
   } = useGameContext()
+
+  const isMobile = useIsMobile()
+  const [selectedTileIndex, setSelectedTileIndex] = useState<number | null>(null)
+
+  const selectedTile =
+    selectedTileIndex !== null ? currentPlayer.rack[selectedTileIndex] : null
+
+  const handleTileSelect = (index: number) => {
+    if (!isMobile) return
+    setSelectedTileIndex(prev => (prev === index ? null : index))
+  }
+
+  const clearSelectedTile = () => setSelectedTileIndex(null)
 
   return (
     <div className="container mx-auto p-6 max-w-7xl">
@@ -46,6 +61,8 @@ const GameContent = () => {
                 onTilePlaced={(row, col, tile) => placeTile(row, col, tile)}
                 onTilePickup={(row, col) => pickupTile(row, col)}
                 disabled={isBotTurn || currentPlayer.isBot}
+                selectedTile={selectedTile}
+                onUseSelectedTile={clearSelectedTile}
               />
               <div className="absolute bottom-2 right-2 bg-secondary rounded p-2 text-sm shadow">
                 {gameState.players.map(p => (
@@ -58,7 +75,11 @@ const GameContent = () => {
             </div>
             {!currentPlayer.isBot && (
               <div className="mt-6 space-y-4">
-                <TileRack tiles={currentPlayer.rack} />
+                <TileRack
+                  tiles={currentPlayer.rack}
+                  selectedTiles={selectedTileIndex !== null ? [selectedTileIndex] : []}
+                  onTileSelect={handleTileSelect}
+                />
                 <div className="flex flex-wrap justify-center gap-2">
                   <Button
                     onClick={confirmMove}

--- a/src/pages/MultiplayerGame.tsx
+++ b/src/pages/MultiplayerGame.tsx
@@ -5,6 +5,8 @@ import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { ScrabbleBoard } from '@/components/ScrabbleBoard'
 import { TileRack } from '@/components/TileRack'
+import { useState } from 'react'
+import { useIsMobile } from '@/hooks/use-mobile'
 import { useMultiplayerGame } from '@/hooks/useMultiplayerGame'
 import { useAuth } from '@/contexts/AuthContext'
 import { Clock, User, Trophy, ArrowLeft } from 'lucide-react'
@@ -37,6 +39,19 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
     getMyScore,
     getCurrentRack
   } = useMultiplayerGame(gameId)
+
+  const isMobile = useIsMobile()
+  const [selectedTileIndex, setSelectedTileIndex] = useState<number | null>(null)
+
+  const selectedTile =
+    selectedTileIndex !== null ? (getCurrentRack() as any)[selectedTileIndex] : null
+
+  const handleTileSelect = (index: number) => {
+    if (!isMobile) return
+    setSelectedTileIndex(prev => (prev === index ? null : index))
+  }
+
+  const clearSelectedTile = () => setSelectedTileIndex(null)
 
   if (!user) {
     return <Navigate to="/auth" replace />
@@ -103,6 +118,8 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
                   onTilePlaced={(row, col, tile) => placeTile(row, col, tile)}
                   onTilePickup={pickupTile}
                   pendingTiles={pendingTiles}
+                  selectedTile={selectedTile}
+                  onUseSelectedTile={clearSelectedTile}
                 />
               </CardContent>
             </Card>
@@ -121,7 +138,11 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <TileRack tiles={currentRack as any} />
+                  <TileRack
+                    tiles={currentRack as any}
+                    selectedTiles={selectedTileIndex !== null ? [selectedTileIndex] : []}
+                    onTileSelect={handleTileSelect}
+                  />
                   
                   {isMyTurn && (
                     <div className="flex gap-2 mt-4">


### PR DESCRIPTION
## Summary
- allow Scrabble board to accept taps when a rack tile is selected
- track selected tile in single and multiplayer games for mobile devices

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887ed50f74c832099b2b5dfb12b476e