### PR TITLE
Fix double bot move on start

### DIFF
--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { GameState, Player, Tile, PlacedTile, TILE_DISTRIBUTION } from '@/types/game'
 import { validateMoveLogic } from '@/utils/moveValidation'
 import { findNewWordsFormed } from '@/utils/newWordFinder'
@@ -467,7 +467,13 @@ export const useGame = () => {
   }, [gameState.currentPlayerIndex, gameState.gameStatus, makeBotMove, isBotTurn, difficulty])
 
   // Effect to reset game when difficulty changes
+  const isFirstRender = useRef(true)
+
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
     if (difficulty) {
       resetGame()
     }


### PR DESCRIPTION
## Summary
- prevent auto-reset triggering duplicate bot moves

## Testing
- `npm run lint` *(fails: require() import issues)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888866557a88320a46787e8b1740c6b