### PR TITLE
Fix tile distribution and pending tiles

### DIFF
--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -230,6 +230,7 @@ export const useGame = () => {
   }, [pendingTiles])
 
   const reshuffleTiles = useCallback(() => {
+    cancelMove()
     setGameState(prev => {
       const currentPlayer = prev.players[prev.currentPlayerIndex]
       const shuffledRack = shuffleArray([...currentPlayer.rack])
@@ -245,9 +246,10 @@ export const useGame = () => {
         players: newPlayers
       }
     })
-  }, [])
+  }, [cancelMove])
 
   const exchangeTiles = useCallback(() => {
+    cancelMove()
     setGameState(prev => {
       const currentPlayer = prev.players[prev.currentPlayerIndex]
       const rackSize = currentPlayer.rack.length
@@ -271,10 +273,11 @@ export const useGame = () => {
         passCount: 0
       }
     })
-  }, [])
+  }, [cancelMove])
 
 
   const passTurn = useCallback(() => {
+    cancelMove()
     setGameState(prev => {
       const newPassCount = (prev.passCount || 0) + 1
       
@@ -292,7 +295,7 @@ export const useGame = () => {
         passCount: newPassCount
       }
     })
-  }, [])
+  }, [cancelMove])
 
   const endTurn = useCallback(() => {
     setGameState(prev => {


### PR DESCRIPTION
## Summary
- use real tile distribution when creating multiplayer games
- clear pending tiles before passing, reshuffling or exchanging

## Testing
- `npm run lint` *(fails: Unexpected any, require-imports)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68888d0f6aa88320a3cbaf35a9410d12