### PR TITLE
Fix blank tile display and move tile counter

### DIFF
--- a/src/components/ScrabbleTile.tsx
+++ b/src/components/ScrabbleTile.tsx
@@ -27,6 +27,8 @@ export const ScrabbleTile = ({
   className
 }: ScrabbleTileProps) => {
   const isMobile = useIsMobile()
+  const displayLetter = isBlank && letter === '' ? '★' : letter
+  const displayPoints = isBlank ? '★' : points
   return (
     <div
       className={cn(
@@ -44,10 +46,10 @@ export const ScrabbleTile = ({
       onDragEnd={onDragEnd}
     >
       <span className="text-tile-text font-bold text-lg leading-none">
-        {letter}
+        {displayLetter}
       </span>
       <span className="text-tile-text text-xs leading-none mt-px">
-        {points}
+        {displayPoints}
       </span>
     </div>
   )

--- a/src/pages/MultiplayerGame.tsx
+++ b/src/pages/MultiplayerGame.tsx
@@ -121,11 +121,7 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
           {/* Game Board */}
           <div className="lg:col-span-3">
             <Card>
-              <CardContent className="p-6 relative">
-                <TileCounter
-                  tileBag={game?.tile_bag || []}
-                  className="absolute bottom-0 right-0 w-20 text-xs"
-                />
+              <CardContent className="p-6">
                 <ScrabbleBoard
                   placedTiles={gameState.board}
                   onTilePlaced={(row, col, tile) => placeTile(row, col, tile)}
@@ -134,6 +130,12 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
                   selectedTile={selectedTile}
                   onUseSelectedTile={clearSelectedTile}
                 />
+                <div className="flex justify-end mt-4">
+                  <TileCounter
+                    tileBag={game?.tile_bag || []}
+                    className="w-20 text-xs"
+                  />
+                </div>
               </CardContent>
             </Card>
 


### PR DESCRIPTION
## Summary
- show a star on blank tiles instead of `0`
- reposition the `TileCounter` below the board so it doesn't overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888ae5011c88320946fa2f9d04ae97d