### PR TITLE
Fix blank tile removal from rack

### DIFF
--- a/src/hooks/useMultiplayerGame.ts
+++ b/src/hooks/useMultiplayerGame.ts
@@ -240,12 +240,14 @@ export const useMultiplayerGame = (gameId: string) => {
       let newRack = [...currentRack]
 
       pendingTiles.forEach(placedTile => {
-        const tileIndex = newRack.findIndex(
-          rackTile =>
+        const tileIndex = newRack.findIndex(rackTile => {
+          if (placedTile.isBlank && rackTile.isBlank) return true
+          return (
             rackTile.letter === placedTile.letter &&
             rackTile.points === placedTile.points &&
             rackTile.isBlank === placedTile.isBlank
-        )
+          )
+        })
         if (tileIndex !== -1) {
           newRack.splice(tileIndex, 1)
         }
@@ -533,9 +535,14 @@ export const useMultiplayerGame = (gameId: string) => {
     // Remove tiles that are currently pending placement
     const rackCopy = [...baseRack]
     pendingTiles.forEach(tile => {
-      const index = rackCopy.findIndex(
-        r => r.letter === tile.letter && r.points === tile.points && r.isBlank === tile.isBlank
-      )
+      const index = rackCopy.findIndex(r => {
+        if (tile.isBlank && r.isBlank) return true
+        return (
+          r.letter === tile.letter &&
+          r.points === tile.points &&
+          r.isBlank === tile.isBlank
+        )
+      })
       if (index !== -1) rackCopy.splice(index, 1)
     })
 


### PR DESCRIPTION
## Summary
- ensure blank tiles get matched properly when removing tiles from the rack
- same logic applied when computing current rack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888c93c0c74832081153a70c281e9cb