### PR TITLE
Improve multiplayer hook typings

### DIFF
--- a/src/types/multiplayer.ts
+++ b/src/types/multiplayer.ts
@@ -12,6 +12,8 @@ export interface Profile {
   updated_at: string
 }
 
+import { PlacedTile, Tile } from './game'
+
 export interface GameRecord {
   id: string
   player1_id: string
@@ -19,10 +21,10 @@ export interface GameRecord {
   current_player_id: string
   status: 'waiting' | 'active' | 'completed' | 'abandoned'
   winner_id?: string
-  board_state: any
-  tile_bag: any[]
-  player1_rack: any[]
-  player2_rack: any[]
+  board_state: Record<string, PlacedTile>
+  tile_bag: Tile[]
+  player1_rack: Tile[]
+  player2_rack: Tile[]
   player1_score: number
   player2_score: number
   turn_deadline?: string
@@ -30,6 +32,8 @@ export interface GameRecord {
   pass_count: number
   created_at: string
   updated_at: string
+  player1?: Pick<Profile, 'username' | 'display_name'>
+  player2?: Pick<Profile, 'username' | 'display_name'>
 }
 
 export interface MoveRecord {
@@ -37,12 +41,12 @@ export interface MoveRecord {
   game_id: string
   player_id: string
   move_type: 'place_tiles' | 'exchange_tiles' | 'pass'
-  tiles_placed: any[]
-  tiles_exchanged: any[]
-  words_formed: any[]
+  tiles_placed: PlacedTile[]
+  tiles_exchanged: Tile[]
+  words_formed: string[]
   score_earned: number
-  board_state_after: any
-  rack_after: any[]
+  board_state_after: Record<string, PlacedTile>
+  rack_after: Tile[]
   created_at: string
 }
 


### PR DESCRIPTION
## Summary
- refine `GameRecord` and `MoveRecord` typings
- remove `any` casts from `useMultiplayerGame`

## Testing
- `npx vitest run`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688a0d8d62688320add290ff1bdc1561