### PR TITLE
Remove console logs from production files

### DIFF
--- a/src/contexts/DictionaryContext.tsx
+++ b/src/contexts/DictionaryContext.tsx
@@ -60,11 +60,9 @@ export const DictionaryProvider: React.FC<DictionaryProviderProps> = ({ children
 
       setWordsSet(wordsSet);
       setIsLoaded(true);
-      console.log(`Dictionary loaded with ${wordsSet.size} words`);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
       setError(errorMessage);
-      console.error('Failed to load dictionary:', err);
       
       // Fallback to basic word set if loading fails
       setWordsSet(createFallbackDictionary());

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -5,10 +5,7 @@ const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
-      "404 Error: User attempted to access non-existent route:",
-      location.pathname
-    );
+    // Intentionally left blank to avoid logging in production
   }, [location.pathname]);
 
   return (


### PR DESCRIPTION
## Summary
- remove `console.log` and `console.error` from DictionaryProvider
- strip error log from NotFound page

## Testing
- `npx vitest run`
- `npm run lint` *(fails: 49 problems, 28 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688a1b8065a883208eef451cdcf28a13