### PR TITLE
Implement rating endpoints and Elo calculation

### DIFF
--- a/rating-api/migrations/0001_add_rating.sql
+++ b/rating-api/migrations/0001_add_rating.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "players" ADD COLUMN "rating" integer DEFAULT 1000 NOT NULL;

--- a/rating-api/package-lock.json
+++ b/rating-api/package-lock.json
@@ -11,7 +11,8 @@
         "dotenv": "^16.4.5",
         "drizzle-orm": "^0.44.4",
         "express": "^4.19.2",
-        "pg": "^8.16.3"
+        "pg": "^8.16.3",
+        "redis": "^4.6.7"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
@@ -949,6 +950,65 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1313,6 +1373,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/concat-map": {
@@ -1844,6 +1913,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2493,6 +2571,23 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -2995,6 +3090,12 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/rating-api/package.json
+++ b/rating-api/package.json
@@ -14,7 +14,8 @@
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.44.4",
     "express": "^4.19.2",
-    "pg": "^8.16.3"
+    "pg": "^8.16.3",
+    "redis": "^4.6.7"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/rating-api/src/elo.test.ts
+++ b/rating-api/src/elo.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { calculateElo } from './elo'
+
+describe('calculateElo', () => {
+  it('blitz win updates ratings with k=32', () => {
+    const res = calculateElo(1000, 1000, 'A', 'blitz')
+    expect(res.newRatingA).toBe(1016)
+    expect(res.newRatingB).toBe(984)
+  })
+
+  it('rapid draw leaves ratings unchanged', () => {
+    const res = calculateElo(1200, 1200, 'draw', 'rapid')
+    expect(res.newRatingA).toBe(1200)
+    expect(res.newRatingB).toBe(1200)
+  })
+})

--- a/rating-api/src/elo.ts
+++ b/rating-api/src/elo.ts
@@ -1,0 +1,34 @@
+export type Mode = 'blitz' | 'rapid' | 'async'
+
+export function kFactor(mode: Mode): number {
+  switch (mode) {
+    case 'blitz':
+      return 32
+    case 'rapid':
+      return 24
+    case 'async':
+      return 16
+    default:
+      return 32
+  }
+}
+
+function expectedScore(ratingA: number, ratingB: number): number {
+  return 1 / (1 + 10 ** ((ratingB - ratingA) / 400))
+}
+
+export function calculateElo(
+  ratingA: number,
+  ratingB: number,
+  winner: 'A' | 'B' | 'draw',
+  mode: Mode,
+): { newRatingA: number; newRatingB: number } {
+  const k = kFactor(mode)
+  const expA = expectedScore(ratingA, ratingB)
+  const expB = expectedScore(ratingB, ratingA)
+  const scoreA = winner === 'A' ? 1 : winner === 'B' ? 0 : 0.5
+  const scoreB = winner === 'B' ? 1 : winner === 'A' ? 0 : 0.5
+  const newRatingA = Math.round(ratingA + k * (scoreA - expA))
+  const newRatingB = Math.round(ratingB + k * (scoreB - expB))
+  return { newRatingA, newRatingB }
+}

--- a/rating-api/src/index.ts
+++ b/rating-api/src/index.ts
@@ -1,13 +1,68 @@
-import express from 'express';
-import { db } from './db';
-import { players } from './schema';
+import express from 'express'
+import { db } from './db'
+import { players, games } from './schema'
+import { eq, desc } from 'drizzle-orm'
+import { createClient } from 'redis'
+import { calculateElo, Mode } from './elo'
 
-const app = express();
-const port = process.env.PORT || 3000;
+const app = express()
+const port = process.env.PORT || 3000
+app.use(express.json())
+
+const redis = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' })
+redis.connect().catch((err) => console.error('Redis connect error', err))
 
 app.get('/ping', (_req, res) => {
   res.json({ status: 'ok' });
 });
+
+app.get('/rating', async (_req, res) => {
+  const cached = await redis.get('leaderboard')
+  if (cached) {
+    return res.json(JSON.parse(cached))
+  }
+  const board = await db.select().from(players).orderBy(desc(players.rating))
+  await redis.set('leaderboard', JSON.stringify(board), { EX: 60 })
+  res.json(board)
+})
+
+app.get('/rating/:id', async (req, res) => {
+  const id = Number(req.params.id)
+  if (Number.isNaN(id)) return res.status(400).json({ error: 'Invalid id' })
+  const [player] = await db.select().from(players).where(eq(players.id, id))
+  if (!player) return res.status(404).json({ error: 'Player not found' })
+  res.json({ id: player.id, rating: player.rating })
+})
+
+app.post('/rating/report', async (req, res) => {
+  const { player1Id, player2Id, winnerId, mode } = req.body as {
+    player1Id: number
+    player2Id: number
+    winnerId: number
+    mode: Mode
+  }
+  if (!player1Id || !player2Id || !winnerId || !mode) {
+    return res.status(400).json({ error: 'Missing fields' })
+  }
+  if (!['blitz', 'rapid', 'async'].includes(mode)) {
+    return res.status(400).json({ error: 'Invalid mode' })
+  }
+  const [p1] = await db.select().from(players).where(eq(players.id, player1Id))
+  const [p2] = await db.select().from(players).where(eq(players.id, player2Id))
+  if (!p1 || !p2) return res.status(404).json({ error: 'Player not found' })
+
+  const winner = winnerId === player1Id ? 'A' : winnerId === player2Id ? 'B' : 'draw'
+  const { newRatingA, newRatingB } = calculateElo(p1.rating, p2.rating, winner, mode)
+
+  await db.transaction(async (tx) => {
+    await tx.update(players).set({ rating: newRatingA }).where(eq(players.id, player1Id))
+    await tx.update(players).set({ rating: newRatingB }).where(eq(players.id, player2Id))
+    await tx.insert(games).values({ player1Id, player2Id, winnerId })
+  })
+
+  await redis.del('leaderboard')
+  res.json({ player1Id, rating1: newRatingA, player2Id, rating2: newRatingB })
+})
 
 app.get('/players', async (_req, res) => {
   const allPlayers = await db.select().from(players);
@@ -17,3 +72,5 @@ app.get('/players', async (_req, res) => {
 app.listen(port, () => {
   console.log(`rating-api listening on port ${port}`);
 });
+
+export default app

--- a/rating-api/src/schema.ts
+++ b/rating-api/src/schema.ts
@@ -5,6 +5,7 @@ export const players = pgTable('players', {
   username: text('username').notNull().unique(),
   password: text('password').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
+  rating: integer('rating').default(1000).notNull(),
 });
 
 export const games = pgTable('games', {


### PR DESCRIPTION
## Summary
- add `rating` column to players schema and migration
- compute Elo rating with new `elo` utility
- expose `/rating`, `/rating/:id`, and `/rating/report` API endpoints
- cache leaderboard using Redis
- test Elo calculation logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688a464d656c8320b0d451aaefb38e04