### PR TITLE
Add lobby page with socket hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import MultiplayerGame from "./pages/MultiplayerGame";
 import Auth from "./pages/Auth";
 import Dashboard from "./pages/Dashboard";
 import Dictionary from "./pages/Dictionary";
+import Lobby from "./pages/Lobby";
 import NotFound from "./pages/NotFound";
 import { BotProvider } from "./contexts/BotContext";
 import { DictionaryProvider } from "./contexts/DictionaryContext";
@@ -39,6 +40,7 @@ const AppRoutes = () => {
           <Route path="/auth" element={<Auth />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/dictionary" element={<Dictionary />} />
+          <Route path="/lobby" element={<Lobby />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/hooks/useLobbySocket.ts
+++ b/src/hooks/useLobbySocket.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+export interface LobbyEntry {
+  id: string
+  host: string
+  players: number
+  maxPlayers: number
+}
+
+const mockLobbies: Record<string, LobbyEntry[]> = {
+  blitz: [
+    { id: 'b1', host: 'Alice', players: 1, maxPlayers: 2 },
+    { id: 'b2', host: 'Bob', players: 2, maxPlayers: 2 }
+  ],
+  rapid: [
+    { id: 'r1', host: 'Charlie', players: 1, maxPlayers: 2 },
+    { id: 'r2', host: 'Dana', players: 1, maxPlayers: 2 }
+  ],
+  async: [
+    { id: 'a1', host: 'Eve', players: 1, maxPlayers: 2 }
+  ]
+}
+
+export const useLobbySocket = (mode: 'blitz' | 'rapid' | 'async') => {
+  const [lobbies, setLobbies] = useState<LobbyEntry[]>([])
+
+  useEffect(() => {
+    // Here we would connect to a websocket and listen for lobby updates.
+    // Using mock data for now.
+    setLobbies(mockLobbies[mode] || [])
+  }, [mode])
+
+  return { lobbies }
+}

--- a/src/pages/Lobby.tsx
+++ b/src/pages/Lobby.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useLobbySocket, LobbyEntry } from '@/hooks/useLobbySocket'
+
+function LobbyList({ lobbies }: { lobbies: LobbyEntry[] }) {
+  if (lobbies.length === 0) {
+    return <p className="text-center text-muted-foreground">No lobbies</p>
+  }
+  return (
+    <div className="space-y-4">
+      {lobbies.map(lobby => (
+        <Card key={lobby.id}>
+          <CardHeader>
+            <CardTitle>{lobby.host}'s game</CardTitle>
+          </CardHeader>
+          <CardContent className="flex items-center justify-between">
+            <span>
+              {lobby.players}/{lobby.maxPlayers} players
+            </span>
+            <Button size="sm">Join</Button>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+const LobbyTab = ({ mode }: { mode: 'blitz' | 'rapid' | 'async' }) => {
+  const { lobbies } = useLobbySocket(mode)
+  return <LobbyList lobbies={lobbies} />
+}
+
+export default function Lobby() {
+  const [tab, setTab] = useState<'blitz' | 'rapid' | 'async'>('blitz')
+  return (
+    <div className="container mx-auto p-6 max-w-3xl">
+      <h1 className="text-2xl font-bold mb-4">Lobby</h1>
+      <Tabs value={tab} onValueChange={v => setTab(v as any)} className="w-full">
+        <TabsList>
+          <TabsTrigger value="blitz">Blitz</TabsTrigger>
+          <TabsTrigger value="rapid">Rapid</TabsTrigger>
+          <TabsTrigger value="async">Async</TabsTrigger>
+        </TabsList>
+        <TabsContent value="blitz">
+          <LobbyTab mode="blitz" />
+        </TabsContent>
+        <TabsContent value="rapid">
+          <LobbyTab mode="rapid" />
+        </TabsContent>
+        <TabsContent value="async">
+          <LobbyTab mode="async" />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Lobby page with blitz/rapid/async tabs
- implement mocked `useLobbySocket` hook
- register new `/lobby` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a4f0d1ca88320b76cf44104ed7a72