### PR TITLE
feat: add rush puzzle tables and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,15 @@ docker-compose up --build
 ```
 
 The API will be accessible at `http://localhost:3000/ping`.
+
+### Database migrations
+
+Drizzle is used for database migrations. From within the `rating-api` directory:
+
+```sh
+# generate a new migration after editing src/schema.ts
+npm run db:generate
+
+# apply all pending migrations
+npm run db:migrate
+```

--- a/rating-api/migrations/0002_rush.sql
+++ b/rating-api/migrations/0002_rush.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "rush_puzzles" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"board" jsonb NOT NULL,
+	"rack" jsonb NOT NULL,
+	"best_score" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "rush_scores" (
+        "id" serial PRIMARY KEY NOT NULL,
+        "user_id" integer NOT NULL,
+        "puzzle_id" integer NOT NULL,
+        "score" integer NOT NULL,
+        "created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "rush_scores" ADD CONSTRAINT "rush_scores_user_id_players_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."players"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "rush_scores" ADD CONSTRAINT "rush_scores_puzzle_id_rush_puzzles_id_fk" FOREIGN KEY ("puzzle_id") REFERENCES "public"."rush_puzzles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "rush_scores_puzzle_id_idx" ON "rush_scores" USING btree ("puzzle_id");--> statement-breakpoint
+CREATE INDEX "rush_scores_user_id_idx" ON "rush_scores" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "rush_scores_score_idx" ON "rush_scores" USING btree ("score" desc);

--- a/rating-api/migrations/meta/0002_snapshot.json
+++ b/rating-api/migrations/meta/0002_snapshot.json
@@ -1,0 +1,317 @@
+{
+  "id": "24e5ca1f-5c7f-4002-b0ba-c9c22c6f5b8a",
+  "prevId": "dec77328-a91f-4a2d-85f9-e90fbce78e28",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "player1_id": {
+          "name": "player1_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player2_id": {
+          "name": "player2_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_id": {
+          "name": "winner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_player1_id_players_id_fk": {
+          "name": "games_player1_id_players_id_fk",
+          "tableFrom": "games",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "games_player2_id_players_id_fk": {
+          "name": "games_player2_id_players_id_fk",
+          "tableFrom": "games",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "games_winner_id_players_id_fk": {
+          "name": "games_winner_id_players_id_fk",
+          "tableFrom": "games",
+          "tableTo": "players",
+          "columnsFrom": [
+            "winner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "players_username_unique": {
+          "name": "players_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rush_puzzles": {
+      "name": "rush_puzzles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board": {
+          "name": "board",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rack": {
+          "name": "rack",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "best_score": {
+          "name": "best_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rush_scores": {
+      "name": "rush_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rush_scores_puzzle_id_idx": {
+          "name": "rush_scores_puzzle_id_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rush_scores_user_id_idx": {
+          "name": "rush_scores_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rush_scores_score_idx": {
+          "name": "rush_scores_score_idx",
+          "columns": [
+            {
+              "expression": "\"score\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rush_scores_user_id_players_id_fk": {
+          "name": "rush_scores_user_id_players_id_fk",
+          "tableFrom": "rush_scores",
+          "tableTo": "players",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rush_scores_puzzle_id_rush_puzzles_id_fk": {
+          "name": "rush_scores_puzzle_id_rush_puzzles_id_fk",
+          "tableFrom": "rush_scores",
+          "tableTo": "rush_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/rating-api/migrations/meta/_journal.json
+++ b/rating-api/migrations/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1753891552630,
       "tag": "0000_dear_mauler",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1755691318569,
+      "tag": "0001_add_rating",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1755691318570,
+      "tag": "0002_rush",
+      "breakpoints": true
     }
   ]
 }

--- a/rating-api/package.json
+++ b/rating-api/package.json
@@ -7,7 +7,8 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "db:migrate": "drizzle-kit push",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
     "db:seed": "tsx src/seed.ts"
   },
   "dependencies": {

--- a/rating-api/src/schema.ts
+++ b/rating-api/src/schema.ts
@@ -1,4 +1,5 @@
-import { pgTable, serial, text, integer, timestamp } from 'drizzle-orm/pg-core';
+import { pgTable, serial, text, integer, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
+import { desc } from 'drizzle-orm';
 
 export const players = pgTable('players', {
   id: serial('id').primaryKey(),
@@ -15,3 +16,29 @@ export const games = pgTable('games', {
   player2Id: integer('player2_id').references(() => players.id),
   winnerId: integer('winner_id').references(() => players.id),
 });
+
+export const rushPuzzles = pgTable('rush_puzzles', {
+  id: serial('id').primaryKey(),
+  board: jsonb('board').notNull(),
+  rack: jsonb('rack').notNull(),
+  bestScore: integer('best_score').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const rushScores = pgTable(
+  'rush_scores',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').references(() => players.id).notNull(),
+    puzzleId: integer('puzzle_id')
+      .references(() => rushPuzzles.id, { onDelete: 'cascade' })
+      .notNull(),
+    score: integer('score').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => ({
+    puzzleIdx: index('rush_scores_puzzle_id_idx').on(table.puzzleId),
+    userIdx: index('rush_scores_user_id_idx').on(table.userId),
+    scoreIdx: index('rush_scores_score_idx').on(desc(table.score)),
+  }),
+);


### PR DESCRIPTION
## Summary
- define rush_puzzles and rush_scores tables with required indexes and foreign keys
- generate migration and adjust package scripts for Drizzle
- document how to generate and run migrations for rating API

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres npm run db:migrate` *(fails: ECONNREFUSED)*
- `npm run build` *(fails: Cannot find module 'vitest', missing types, etc.)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b8b354888320aa5ac0c5c4afe96f