### PR TITLE
Fix Rush mode hint highlighting and scoring thresholds

### DIFF
--- a/src/pages/RushGame.tsx
+++ b/src/pages/RushGame.tsx
@@ -384,10 +384,10 @@ const RushGame = () => {
 
   // Generate highlight squares for hints
   const highlightSquares = []
-  if (currentTargetMove && gameState.hints.anchorRevealed && currentTargetMove.anchorCell) {
+  if (currentTargetMove && gameState.hints.anchorRevealed && currentTargetMove.startCell) {
     highlightSquares.push({
-      row: currentTargetMove.anchorCell.row,
-      col: currentTargetMove.anchorCell.col,
+      row: currentTargetMove.startCell.row,
+      col: currentTargetMove.startCell.col,
       type: 'anchor' as const
     })
   }

--- a/src/types/rush.ts
+++ b/src/types/rush.ts
@@ -4,7 +4,7 @@ export interface RushMove {
   tiles: PlacedTile[]
   words: string[]
   score: number
-  anchorCell?: { row: number, col: number }
+  startCell?: { row: number, col: number }
   mainWordLength?: number
   lettersUsed?: string[]
 }

--- a/src/utils/rushPuzzleGenerator15x15.ts
+++ b/src/utils/rushPuzzleGenerator15x15.ts
@@ -156,13 +156,12 @@ function generateTopMovesWithBot(
   if (!isDictionaryLoaded) {
     // Fallback moves if dictionary not loaded with proper hint data
     const fallbackTiles = Array.from(board.values()).slice(0, 2)
+    const startTile = fallbackTiles[0] ?? { row: 7, col: 7 }
     return [{
       tiles: fallbackTiles,
       words: ['WORD'],
       score: 50,
-      anchorCell: fallbackTiles.length > 0 ? 
-        { row: fallbackTiles[0].row, col: fallbackTiles[0].col } : 
-        { row: 7, col: 7 },
+      startCell: { row: startTile.row, col: startTile.col },
       mainWordLength: 4,
       lettersUsed: rack.slice(0, 2).map(t => t.letter).sort()
     }]
@@ -185,16 +184,20 @@ function generateTopMovesWithBot(
     .slice(0, 5)
     .map(move => {
       // Calculate hints for this move
-      const anchorCell = move.tiles.length > 0 ? { row: move.tiles[0].row, col: move.tiles[0].col } : undefined
-      const mainWord = move.words.length > 0 ? move.words[0] : ''
+      const isHorizontal = move.tiles.every(t => t.row === move.tiles[0].row)
+      const startTile = isHorizontal
+        ? move.tiles.reduce((min, t) => (t.col < min.col ? t : min), move.tiles[0])
+        : move.tiles.reduce((min, t) => (t.row < min.row ? t : min), move.tiles[0])
+      const startCell = { row: startTile.row, col: startTile.col }
+      const mainWordLength = move.words.length > 0 ? Math.max(...move.words.map(w => w.length)) : undefined
       const lettersUsed = move.tiles.map(tile => tile.letter).sort()
-      
+
       return {
         tiles: move.tiles,
         words: move.words,
         score: move.score,
-        anchorCell,
-        mainWordLength: mainWord.length,
+        startCell,
+        mainWordLength,
         lettersUsed
       }
     })
@@ -213,8 +216,8 @@ export function generateLocal15x15RushPuzzle(
     const rack = tileBag.splice(0, 7)
     
     const topMoves = generateTopMovesWithBot(board, rack, isValidWord, isDictionaryLoaded)
-    
-    if (topMoves.length >= 3 && topMoves[0].score >= 45) {
+
+    if (topMoves.length >= 3 && topMoves[0].score >= 30) {
       return {
         id: `local-15x15-${Date.now()}`,
         board: Array.from(board.values()),
@@ -232,13 +235,13 @@ export function generateLocal15x15RushPuzzle(
   const rack = tileBag.splice(0, 7)
   
   // Generate fallback moves with proper hint data
+  const fallbackTiles = Array.from(board.values()).slice(0, 2)
+  const startTile = fallbackTiles[0] ?? { row: 7, col: 7 }
   const fallbackMoves = [{
-    tiles: Array.from(board.values()).slice(0, 2),
+    tiles: fallbackTiles,
     words: ['WORD'],
     score: 50,
-    anchorCell: Array.from(board.values()).length > 0 ? 
-      { row: Array.from(board.values())[0].row, col: Array.from(board.values())[0].col } : 
-      { row: 7, col: 7 },
+    startCell: { row: startTile.row, col: startTile.col },
     mainWordLength: 4,
     lettersUsed: rack.slice(0, 2).map(t => t.letter).sort()
   }]


### PR DESCRIPTION
## Summary
- highlight starting cell for Rush mode hints instead of a static position
- show correct word length and letters in top moves
- lower Rush puzzle score requirement to 30 points

## Testing
- `npm test` *(fails: document is not defined, describe is not defined)*
- `npm run lint` *(fails: 69 problems, including no-explicit-any and hooks rules violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ad0c27e08320b9a16fc05e3b20f7