### PR TITLE
Fix conditional hook call causing React error 310 in multiplayer game

### DIFF
--- a/src/pages/MultiplayerGame.tsx
+++ b/src/pages/MultiplayerGame.tsx
@@ -49,6 +49,12 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
   const [selectedTileIndex, setSelectedTileIndex] = useState<number | null>(null)
   const [exchangeOpen, setExchangeOpen] = useState(false)
 
+  const opponentId =
+    game && user ? (game.player1_id === user.id ? game.player2_id : game.player1_id) : undefined
+
+  const { rating: myRating } = usePlayerRating(user?.id)
+  const { rating: opponentRating } = usePlayerRating(opponentId)
+
   if (!game || !gameState) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -65,8 +71,6 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
   const opponent = getOpponentInfo()
   const myScore = getMyScore()
   const currentRack = getCurrentRack()
-  const { rating: myRating } = usePlayerRating(user.id)
-  const { rating: opponentRating } = usePlayerRating(opponent?.id)
 
   const selectedTile =
     selectedTileIndex !== null ? (currentRack as any)[selectedTileIndex] : null


### PR DESCRIPTION
## Summary
- ensure consistent hook usage in multiplayer page to avoid React error #310 when loading opponent ratings

## Testing
- `npm test` *(fails: Cannot find package 'drizzle-orm/node-postgres', ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ad93fcbdb8832092ed5844e035d013