### PR TITLE
Fix scoring and board interactions

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -174,6 +174,15 @@ const GameContent = () => {
                 disabled={isBotTurn || currentPlayer.isBot}
                 selectedTile={selectedTile}
                 onUseSelectedTile={clearSelectedTile}
+                boardMap={gameState.board}
+                pendingTiles={pendingTiles}
+                onPlaceTile={(row, col, tile) => {
+                  const gameTile = 'value' in tile && !('points' in tile)
+                    ? { letter: tile.letter, points: (tile as any).value, isBlank: (tile as any).isBlank }
+                    : tile as any
+                  placeTile(row, col, gameTile)
+                }}
+                onPickupTile={pickupTile}
               />
               <div className="absolute bottom-2 right-2 bg-secondary rounded p-2 text-sm shadow">
                 {gameState.players.map(p => (

--- a/src/utils/newScoring.ts
+++ b/src/utils/newScoring.ts
@@ -54,7 +54,7 @@ export const calculateNewWordScore = (
   // Calculate base score with letter multipliers
   word.tiles.forEach(tile => {
     const position = `${tile.row},${tile.col}`
-    let letterScore = tile.points
+    let letterScore = Number(tile.points) || 0
     
     // Apply special square bonuses only for newly placed tiles
     if (newTilePositions.has(position)) {

--- a/src/utils/scoring.ts
+++ b/src/utils/scoring.ts
@@ -54,7 +54,7 @@ export const calculateWordScore = (
   // Calculate base score with letter multipliers
   word.tiles.forEach(tile => {
     const position = `${tile.row},${tile.col}`
-    let letterScore = tile.points
+    let letterScore = Number(tile.points) || 0
     
     // Apply special square bonuses only for newly placed tiles
     if (newTilePositions.has(position)) {


### PR DESCRIPTION
## Summary
- handle undefined tile points in scoring functions
- connect board component to game state for proper tile placement and bot moves

## Testing
- `npm test` *(fails: Cannot find package 'drizzle-orm/node-postgres', ReferenceError: describe is not defined, document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2b8a49c8320ab80853e83921cf5