### PR TITLE
fix: restore blank tile selection

### DIFF
--- a/src/components/TileRack.tsx
+++ b/src/components/TileRack.tsx
@@ -23,6 +23,7 @@ export const TileRack = ({ tiles, selectedTiles = [], onTileSelect, onTileDragSt
             key={index}
             letter={tile.letter}
             points={('value' in tile ? (tile as any).value : (tile as any).points) as number}
+            isBlank={(tile as any).isBlank}
             isSelected={selectedTiles.includes(index)}
             isDragging={draggingIndex === index}
             onSelect={() => onTileSelect?.(index)}

--- a/src/hooks/useGame.ts
+++ b/src/hooks/useGame.ts
@@ -105,13 +105,14 @@ export const useGame = () => {
     if (tileIndex === -1) return // Tile not found in pending tiles
     
     const tile = pendingTiles[tileIndex]
-    
+    const returnedTile = tile.isBlank ? { ...tile, letter: '' } : tile
+
     setGameState(prev => {
       const currentPlayer = prev.players[prev.currentPlayerIndex]
       const newPlayers = [...prev.players]
       newPlayers[prev.currentPlayerIndex] = {
         ...currentPlayer,
-        rack: [...currentPlayer.rack, tile]
+        rack: [...currentPlayer.rack, returnedTile]
       }
       
       return {

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -6,6 +6,7 @@ import { TileRack } from "@/components/TileRack"
 import { TileActions } from "@/components/TileActions"
 import { DictionaryLoader } from "@/components/DictionaryLoader"
 import { AnalysisPanel } from "@/components/AnalysisPanel"
+import { BlankTileDialog } from "@/components/BlankTileDialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ArrowLeft, Trophy, BarChart3 } from "lucide-react"
@@ -31,6 +32,7 @@ const GameContent = () => {
 
   const isMobile = useIsMobile()
   const [selectedTileIndex, setSelectedTileIndex] = useState<number | null>(null)
+  const [blankTile, setBlankTile] = useState<{ row: number, col: number, tile: any } | null>(null)
 
   const selectedTile = selectedTileIndex !== null 
     ? { 
@@ -156,6 +158,18 @@ const GameContent = () => {
 
   return (
     <div className="container mx-auto p-6 max-w-7xl">
+      <BlankTileDialog
+        open={!!blankTile}
+        onOpenChange={(open) => {
+          if (!open) setBlankTile(null)
+        }}
+        onSelect={(letter) => {
+          if (blankTile) {
+            placeTile(blankTile.row, blankTile.col, { ...blankTile.tile, letter })
+            setBlankTile(null)
+          }
+        }}
+      />
       <div className="mb-4 flex items-center gap-4">
         <Link to="/">
           <Button variant="outline" size="sm">
@@ -180,7 +194,11 @@ const GameContent = () => {
                   const gameTile = 'value' in tile && !('points' in tile)
                     ? { letter: tile.letter, points: (tile as any).value, isBlank: (tile as any).isBlank }
                     : tile as any
-                  placeTile(row, col, gameTile)
+                  if (gameTile.isBlank && gameTile.letter === '') {
+                    setBlankTile({ row, col, tile: gameTile })
+                  } else {
+                    placeTile(row, col, gameTile)
+                  }
                 }}
                 onPickupTile={pickupTile}
               />


### PR DESCRIPTION
## Summary
- restore blank tile dialog for choosing letter
- show blank tiles in rack and reset letter when picked up
- handle blank tiles across single, multiplayer, and rush modes

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom', supertest missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adb94e0de8832086df18c4ad3953dd