### PR TITLE
feat: add surrender option to multiplayer game

### DIFF
--- a/src/pages/MultiplayerGame.tsx
+++ b/src/pages/MultiplayerGame.tsx
@@ -41,6 +41,7 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
     submitMove,
     exchangeTiles,
     passTurn,
+    surrenderGame,
     getOpponentInfo,
     getMyScore,
     getCurrentRack
@@ -312,13 +313,22 @@ function MultiplayerGameContent({ gameId }: { gameId: string }) {
                     Back to Dashboard
                   </Button>
                 </Link>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   className="w-full"
                   onClick={() => window.location.reload()}
                 >
                   Refresh Game
                 </Button>
+                {game.status === 'active' && (
+                  <Button
+                    variant="destructive"
+                    className="w-full"
+                    onClick={surrenderGame}
+                  >
+                    Surrender
+                  </Button>
+                )}
               </CardContent>
             </Card>
           </div>

--- a/src/types/multiplayer.ts
+++ b/src/types/multiplayer.ts
@@ -40,7 +40,7 @@ export interface MoveRecord {
   id: string
   game_id: string
   player_id: string
-  move_type: 'place_tiles' | 'exchange_tiles' | 'pass'
+  move_type: 'place_tiles' | 'exchange_tiles' | 'pass' | 'resign'
   tiles_placed: PlacedTile[]
   tiles_exchanged: Tile[]
   words_formed: string[]

--- a/supabase/migrations/20250826120000_add_resign_move_type.sql
+++ b/supabase/migrations/20250826120000_add_resign_move_type.sql
@@ -1,0 +1,3 @@
+-- Allow resign move type
+ALTER TABLE public.moves DROP CONSTRAINT IF EXISTS moves_move_type_check;
+ALTER TABLE public.moves ADD CONSTRAINT moves_move_type_check CHECK (move_type IN ('place_tiles', 'exchange_tiles', 'pass', 'resign'));


### PR DESCRIPTION
## Summary
- allow players to surrender and award the win to the opponent
- expose surrender action in multiplayer UI
- support `resign` move type in database schema

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom'; Cannot find package 'supertest'; ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68adca734db88320bf7fbc59fb62576d