### PR TITLE
Enable game analysis for local games

### DIFF
--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, ReactNode } from 'react'
 import { useGame } from '@/hooks/useGame'
 import { GameState, Player, Tile, PlacedTile } from '@/types/game'
+import type { GameMove } from '@/hooks/useGameAnalysis'
 
 interface GameContextType {
   gameState: GameState
@@ -19,6 +20,8 @@ interface GameContextType {
   isSurrendered: boolean
   currentPlayer: Player
   isCurrentPlayerTurn: (playerId: string) => boolean
+  moveHistory: GameMove[]
+  gameId: string
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined)
@@ -54,7 +57,9 @@ export const GameProvider = ({ children }: GameProviderProps) => {
     isBotTurn,
     isSurrendered,
     currentPlayer,
-    isCurrentPlayerTurn
+    isCurrentPlayerTurn,
+    moveHistory,
+    gameId
   } = gameLogic
 
   return (
@@ -75,7 +80,9 @@ export const GameProvider = ({ children }: GameProviderProps) => {
         isBotTurn,
         isSurrendered,
         currentPlayer,
-        isCurrentPlayerTurn
+        isCurrentPlayerTurn,
+        moveHistory,
+        gameId
       }}
     >
       {children}

--- a/src/hooks/useGameAnalysis.ts
+++ b/src/hooks/useGameAnalysis.ts
@@ -13,8 +13,8 @@ export interface GameMove {
   dir?: 'H' | 'V'
 }
 
-export const useGameAnalysis = (gameId: string | null) => {
-  const [moves, setMoves] = useState<GameMove[]>([])
+export const useGameAnalysis = (gameId: string | null, initialMoves: GameMove[] = []) => {
+  const [moves, setMoves] = useState<GameMove[]>(initialMoves)
   const [analysis, setAnalysis] = useState<AnalysisResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -85,8 +85,12 @@ export const useGameAnalysis = (gameId: string | null) => {
   }
 
   useEffect(() => {
-    fetchMoves()
-  }, [gameId])
+    if (initialMoves.length > 0) {
+      setMoves(initialMoves)
+    } else if (gameId) {
+      fetchMoves()
+    }
+  }, [gameId, initialMoves])
 
   return {
     moves,

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -30,13 +30,15 @@ const GameContent = () => {
     exchangeTiles,
     isBotTurn,
     surrenderGame,
-    isSurrendered
+    isSurrendered,
+    moveHistory,
+    gameId
   } = useGameContext()
 
   const isMobile = useIsMobile()
   const [selectedTileIndex, setSelectedTileIndex] = useState<number | null>(null)
   const [blankTile, setBlankTile] = useState<{ row: number, col: number, tile: any } | null>(null)
-  const { moves, analysis, analyzeGame, loading: analysisLoading } = useGameAnalysis(null)
+  const { moves, analysis, analyzeGame, loading: analysisLoading, error: analysisError } = useGameAnalysis(gameId, moveHistory)
 
   const humanPlayer = gameState.players.find(p => !p.isBot) || currentPlayer
   const rackToShow = gameState.gameMode === 'bot' ? humanPlayer.rack : currentPlayer.rack
@@ -76,27 +78,6 @@ const GameContent = () => {
       analyzeGame()
     }
   }, [gameState.gameStatus, moves.length, analyzeGame])
-
-  // Generate mock game data for analysis (in real app, this would come from game history)
-  const generateAnalysisData = () => {
-    const moves: Array<{row: number, col: number, word: string, score: number, direction: 'H' | 'V', rackBefore: string}> = []
-    
-    // Convert board state to moves (simplified for demo)
-    const boardEntries = Array.from(gameState.board.entries())
-    if (boardEntries.length > 0) {
-      // Mock some moves based on current board state
-      moves.push({
-        row: 7,
-        col: 7,
-        word: "HELLO",
-        score: 10,
-        direction: 'H',
-        rackBefore: "HELLOWR"
-      })
-    }
-    
-    return { moves, lexicon: 'NWL' as const }
-  }
 
   if (gameState.gameStatus === 'finished') {
     const winner = gameState.players.reduce((prev, current) => (prev.score > current.score) ? prev : current)
@@ -184,6 +165,10 @@ const GameContent = () => {
               </div>
             ) : analysis ? (
               <AnalysisPanel analysis={analysis} moves={moves} />
+            ) : analysisError ? (
+              <div className="text-center py-8">
+                <p className="text-destructive">{analysisError}</p>
+              </div>
             ) : (
               <div className="text-center py-8">
                 <p className="text-muted-foreground">No analysis available for this game.</p>


### PR DESCRIPTION
## Summary
- track local game moves and generate a unique game id
- extend game analysis hook to accept injected moves and skip fetching
- show rating API errors in the analysis tab

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom'; ReferenceError: describe is not defined)*
- `npm run lint` *(fails: Unexpected any, missing dependencies, forbidden require)*

------
https://chatgpt.com/codex/tasks/task_e_68b088b8dbd08320b4cb75be887abce9