### PR TITLE
Enlarge tile letters and move score bottom-right

### DIFF
--- a/src/components/ScrabbleTile.tsx
+++ b/src/components/ScrabbleTile.tsx
@@ -41,7 +41,7 @@ export const ScrabbleTile = ({
       className={cn(
         // Responsive dimensions: match board cell sizes
         isOnBoard ? "w-6 h-6 xs:w-7 xs:h-7 sm:w-8 sm:h-8 md:w-9 md:h-9 lg:w-10 lg:h-10" : "w-12 h-12",
-        "bg-tile rounded-md flex flex-col items-center justify-center select-none",
+        "relative bg-tile rounded-md flex items-center justify-center select-none",
         // Different transition behavior for on-board vs off-board tiles
         isOnBoard ? "transition-colors" : "transition-all",
 
@@ -61,18 +61,20 @@ export const ScrabbleTile = ({
     >
       <span
         className={cn(
-          "text-tile-text font-bold leading-none",
-          // Responsive text sizes for mobile
-          isOnBoard ? "text-[9px] xs:text-[10px] sm:text-[11px] md:text-sm" : "text-xl"
+          "text-tile-text font-bold leading-none pointer-events-none",
+          // Larger letter to nearly fill tile
+          isOnBoard
+            ? "text-[14px] xs:text-[16px] sm:text-[18px] md:text-lg"
+            : "text-3xl"
         )}
       >
         {displayLetter}
       </span>
       <span
         className={cn(
-          "text-tile-text leading-none mt-px",
+          "absolute bottom-0.5 right-0.5 text-tile-text leading-none pointer-events-none",
           // Responsive points size
-          isOnBoard ? "text-[7px] xs:text-[8px] sm:text-[9px] md:text-[10px]" : "text-sm"
+          isOnBoard ? "text-[8px] xs:text-[9px] sm:text-[10px] md:text-xs" : "text-xs"
         )}
       >
         {displayPoints}


### PR DESCRIPTION
## Summary
- make tile letters nearly fill their tiles
- reposition score to bottom-right corner

## Testing
- `npm test -- --run`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b187c706008320bb73927edb82cf50